### PR TITLE
Fix EventBus sorting and add unregister features

### DIFF
--- a/src/main/java/net/ririfa/beacon/javaExtension/HandlerUtil.java
+++ b/src/main/java/net/ririfa/beacon/javaExtension/HandlerUtil.java
@@ -34,8 +34,6 @@ public class HandlerUtil {
             Handler<T> handler,
             Long timeout
     ) {
-        Class<?> clazz = instance.getClass();
-
         Function0<Boolean> kc = toKotlinFunction0(condition);
 
         EventBus.registerEventHook(
@@ -90,8 +88,6 @@ public class HandlerUtil {
             ReturnableHandler<T, R> handler,
             Long timeout
     ) {
-        Class<?> clazz = instance.getClass();
-
         Function0<Boolean> kc = toKotlinFunction0(condition);
 
         EventBus.registerReturnableEventHook(


### PR DESCRIPTION
## Summary
- fix returnable hook sorting so priority actually takes effect
- add unregister functions to remove hooks
- clear returnable registry on shutdown
- drop unused variables in HandlerUtil

## Testing
- `./gradlew build` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_6843add34b7483258452325c90261d7f